### PR TITLE
Expose the swaggerType.enum values as a sequence in typespec.enum.

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -28,6 +28,7 @@ function convertType(swaggerType, swagger) {
         typespec.tsType = swaggerType.enum.map(function(str) { return JSON.stringify(str); }).join(' | ');
         typespec.isAtomic = true;
         typespec.isEnum = true;
+        typespec.enum = swaggerType.enum;
     } else if (swaggerType.type === 'string') {
         typespec.tsType = 'string';
     } else if (swaggerType.type === 'number' || swaggerType.type === 'integer') {


### PR DESCRIPTION
This lets the template access the sequence of individual enum values, and not just the string literal union type.