### PR TITLE
support built-in dictionary type

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -15,6 +15,8 @@ function convertType(swaggerType, swagger) {
     var typespec = {
         description: swaggerType.description,
         isEnum: false,
+        isArray: false,
+        isDictionary: false,
         isNullable: !swaggerType.required,
         requiredPropertyNames: (swaggerType.type === 'object' && swaggerType.required) || []
     };
@@ -38,10 +40,12 @@ function convertType(swaggerType, swagger) {
     } else if (swaggerType.type === 'array') {
         typespec.elementType = convertType(swaggerType.items);
         typespec.tsType = `Array<${typespec.elementType.target || typespec.elementType.tsType || 'any'}>`;
+        typespec.isArray = true;
     } else if (swaggerType.type === 'object' && swaggerType.hasOwnProperty('additionalProperties')) {
         // case where a it's a Dictionary<string, someType>
         typespec.elementType = convertType(swaggerType.additionalProperties);
-        typespec.tsType = `Dictionary<${typespec.elementType.target || typespec.elementType.tsType || 'any'}>`;
+        typespec.tsType = `{ [key: string]: ${typespec.elementType.target || typespec.elementType.tsType || 'any'} }`;
+        typespec.isDictionary = true;
     } else /*if (swaggerType.type === 'object')*/ { //remaining types are created as objects
         if (swaggerType.minItems >= 0 && swaggerType.hasOwnProperty('title') && !swaggerType.$ref) {
             typespec.tsType = 'any';
@@ -79,8 +83,6 @@ function convertType(swaggerType, swagger) {
     // Since Mustache does not provide equality checks, we need to do the case distinction via explicit booleans
     typespec.isRef = typespec.tsType === 'ref';
     typespec.isObject = typespec.tsType === 'object';
-    typespec.isArray = typespec.tsType.indexOf('Array<') > -1;
-    typespec.isDictionary = typespec.tsType.indexOf('Dictionary<') > -1;
     typespec.isAtomic = typespec.isAtomic || _.includes(['string', 'number', 'boolean', 'any'], typespec.tsType);
 
     return typespec;

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -6,6 +6,7 @@
 %><%#isObject%>{<%#properties%>
 '<%name%>': <%>type%><%/properties%>
 }<%/isObject%><%!
-%><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%>
+%><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%><%!
+%><%#isDictionary%>{[key: string]: <%#elementType%><%>type%><%/elementType%>}<%/isDictionary%>
 <%={{ }}=%>
 {{/tsType}}


### PR DESCRIPTION
1 `Dictionary` is a custom type, let's use typescript built-in type `{ [key: string]: value }`
2 isDictionary is ignored in default templates