### PR TITLE
Improve whitespace in generated output

### DIFF
--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -8,11 +8,16 @@ export type RequestHeaders = {
     [header: string]: string;
 }
 export type RequestHeadersHandler = (headers: RequestHeaders) => RequestHeaders;
+
 export type ConfigureAgentHandler = (agent: SuperAgentStatic) => SuperAgentStatic;
+
 export type ConfigureRequestHandler = (agent: SuperAgentRequest) => SuperAgentRequest;
+
 export type CallbackHandler = (err: any, res?: request.Response) => void;
+
 {{#definitions}}
 export type {{&name}} = {{#tsType}}{{> type}}{{/tsType}};
+
 {{/definitions}}
 
 export type Logger = { log: (line: string) => any };

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -6,7 +6,8 @@
 
 %><%#isAtomic%><%&tsType%><%/isAtomic%><%!
 
-%><%#isObject%>{<%#properties%>'<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>}<%/isObject%><%!
+%><%#isObject%>{
+<%#properties%>    '<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>}<%/isObject%><%!
 
 %><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%><%!
 

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -3,9 +3,7 @@
 {{=<% %>=}}
 <%#isRef%><%target%><%/isRef%><%!
 %><%#isAtomic%><%&tsType%><%/isAtomic%><%!
-%><%#isObject%>{<%#properties%>
-'<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>
-}<%/isObject%><%!
+%><%#isObject%>{<%#properties%>'<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>}<%/isObject%><%!
 %><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%><%!
 %><%#isDictionary%>{[key: string]: <%#elementType%><%>type%><%/elementType%>}<%/isDictionary%>
 <%={{ }}=%>

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -1,10 +1,16 @@
 {{#tsType}}
 {{! must use different delimiters to avoid ambiguities when delimiters directly follow a literal brace {. }}
-{{=<% %>=}}
-<%#isRef%><%target%><%/isRef%><%!
+{{=<% %>=}}<%!
+
+%><%#isRef%><%target%><%/isRef%><%!
+
 %><%#isAtomic%><%&tsType%><%/isAtomic%><%!
+
 %><%#isObject%>{<%#properties%>'<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>}<%/isObject%><%!
+
 %><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%><%!
-%><%#isDictionary%>{[key: string]: <%#elementType%><%>type%><%/elementType%>}<%/isDictionary%>
-<%={{ }}=%>
+
+%><%#isDictionary%>{[key: string]: <%#elementType%><%>type%><%/elementType%>}<%/isDictionary%><%!
+
+%><%={{ }}=%>
 {{/tsType}}


### PR DESCRIPTION
No newlines between properties of TypeScript interface. Also, separate some types by new lines.

I prettify generated code automatically via `prettier`, and this especially improves the prettified results. @mtennoe are you interested in a PR for such an automatic prettification?
