### PR TITLE
Override path

### DIFF
--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -2,11 +2,15 @@
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
 {{/isSingleton}}{{/parameters}}
 $queryParameters?: any, 
-$domain?: string
+$domain?: string,
+$path?: string | ((path: string) => string)
 }): string {
     let queryParameters: any = {};
     const domain = parameters.$domain ? parameters.$domain : this.domain;
     let path = '{{&path}}';
+    if (parameters.$path) {
+        path = (typeof(parameters.$path) === 'function') ? parameters.$path(path) : parameters.$path;
+    } 
     {{#parameters}}
         {{#isQueryParameter}}
             {{#isSingleton}}
@@ -65,10 +69,14 @@ $domain?: string
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
 {{/isSingleton}}{{/parameters}}
     $queryParameters?: any,
-    $domain?: string
+    $domain?: string,
+    $path?: string | ((path: string) => string)
 }): Promise<ResponseWithBody<{{&successfulResponseType}}>> {
     const domain = parameters.$domain ? parameters.$domain : this.domain;
     let path = '{{&path}}';
+    if (parameters.$path) {
+        path = (typeof(parameters.$path) === 'function') ? parameters.$path(path) : parameters.$path;
+    } 
     let body: any;
     let queryParameters: any = {};
     let headers: any = {};

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -11,6 +11,7 @@ $path?: string | ((path: string) => string)
     if (parameters.$path) {
         path = (typeof(parameters.$path) === 'function') ? parameters.$path(path) : parameters.$path;
     } 
+
     {{#parameters}}
         {{#isQueryParameter}}
             {{#isSingleton}}
@@ -77,6 +78,7 @@ $path?: string | ((path: string) => string)
     if (parameters.$path) {
         path = (typeof(parameters.$path) === 'function') ? parameters.$path(path) : parameters.$path;
     } 
+
     let body: any;
     let queryParameters: any = {};
     let headers: any = {};


### PR DESCRIPTION
This PR adds the possibility to override the request path via `$path` parameter, similar to existing `$domain` parameter.

The path can be overridden by a simple string or by callback (the latter is not possible for `$domain`).