### PR TITLE
Formalize common request options in generated code

### DIFF
--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -21,6 +21,12 @@ export interface ResponseWithBody<T> extends Response {
     body: T;
 }
 
+export interface CommonRequestOptions {
+  $queryParameters?: {[param: string]: any};
+  $domain?: string;
+  $path?: string | ((path: string) => string);
+}
+
 /**
  * {{&description}}
  * @class {{&className}}

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -2,11 +2,15 @@
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
 {{/isSingleton}}{{/parameters}}
 $queryParameters?: any, 
-$domain?: string
+$domain?: string,
+$path?: string | ((path: string) => string)
 }): string {
     let queryParameters: any = {};
     const domain = parameters.$domain ? parameters.$domain : this.domain;
     let path = '{{&path}}';
+    if (parameters.$path) {
+        path = (typeof(parameters.$path) === 'function') ? parameters.$path(path) : parameters.$path;
+    } 
     {{#parameters}}
         {{#isQueryParameter}}
             {{#isSingleton}}
@@ -65,10 +69,14 @@ $domain?: string
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
 {{/isSingleton}}{{/parameters}}
     $queryParameters?: any,
-    $domain?: string
+    $domain?: string,
+    $path?: string | ((path: string) => string)
 }): Promise<ResponseWithBody<{{&successfulResponseType}}>> {
     const domain = parameters.$domain ? parameters.$domain : this.domain;
     let path = '{{&path}}';
+    if (parameters.$path) {
+        path = (typeof(parameters.$path) === 'function') ? parameters.$path(path) : parameters.$path;
+    } 
     let body: any;
     let queryParameters: any = {};
     let headers: any = {};

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -1,9 +1,6 @@
 {{&methodName}}URL(parameters: {
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
 {{/isSingleton}}{{/parameters}}
-// $queryParameters?: any, 
-//  $domain?: string,
-//  $path?: string | ((path: string) => string)
 } & CommonRequestOptions): string {
     let queryParameters: any = {};
     const domain = parameters.$domain ? parameters.$domain : this.domain;

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -1,10 +1,10 @@
 {{&methodName}}URL(parameters: {
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
 {{/isSingleton}}{{/parameters}}
-$queryParameters?: any, 
-$domain?: string,
-$path?: string | ((path: string) => string)
-}): string {
+// $queryParameters?: any, 
+//  $domain?: string,
+//  $path?: string | ((path: string) => string)
+} & CommonRequestOptions): string {
     let queryParameters: any = {};
     const domain = parameters.$domain ? parameters.$domain : this.domain;
     let path = '{{&path}}';


### PR DESCRIPTION
Extract common request options to own exported interface

**Important**: this PR depends on PR #42 (which introduces `$path`)
