### PR TITLE
Improve queryParameter assignment

### DIFF
--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -33,7 +33,7 @@ $domain?: string
         {{/isPathParameter}}
     {{/parameters}}
     
-    if (parameters.$queryParameters != undefined) {
+    if (parameters.$queryParameters !== undefined && parameters.$queryParameters !== null) {
         queryParameters = {
             ...queryParameters,
             ...parameters.$queryParameters

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -33,10 +33,11 @@ $domain?: string
         {{/isPathParameter}}
     {{/parameters}}
     
-    if(parameters.$queryParameters) {
-        Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-            queryParameters[parameterName] = parameters.$queryParameters[parameterName];
-        });
+    if (parameters.$queryParameters != undefined) {
+        queryParameters = {
+            ...queryParameters,
+            ...parameters.$queryParameters
+        }
     }
 
     {{^isBodyParameter}}


### PR DESCRIPTION
Changes:

* `queryParameters` are ignored if set to `null` or `undefined`, but not for other falsy values (so we detect them as errors)
* uses spread operator to improve readability

