### PR TITLE
Arrays are always arrays

### DIFF
--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -4,7 +4,7 @@
 <%#isRef%><%target%><%/isRef%><%!
 %><%#isAtomic%><%&tsType%><%/isAtomic%><%!
 %><%#isObject%>{<%#properties%>'<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>}<%/isObject%><%!
-%><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%><%!
+%><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>><%/isArray%><%!
 %><%#isDictionary%>{[key: string]: <%#elementType%><%>type%><%/elementType%>}<%/isDictionary%>
 <%={{ }}=%>
 {{/tsType}}


### PR DESCRIPTION
*So this one could be controversial, and is backwards-incompatible.*

Currently, when generator encounters an OpenAPI array definition, it generates

```code
   element: Array<type> | type
```

This PR removes the optional `| type`.

The reasoning for this could be (I haven't verified this) that the current generator lacks handling of [`oneOf`](https://json-schema.org/understanding-json-schema/reference/combining.html).

But - for my understanding - the PR represents the correct behavior. It also simplifies handling of array elements as we don't always have to handle two code paths in TS when there is just an array.

I don't know if anyone really needs the old, "fuzzy" behavior. If yes, there could be an option for this?

@mtennoe let me know what you think.

**Note**: this PR depends on PR #41 
