### PR TITLE
[Bugfix] Missing semicolon after object properties

### DIFF
--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -7,7 +7,7 @@
 %><%#isAtomic%><%&tsType%><%/isAtomic%><%!
 
 %><%#isObject%>{
-<%#properties%>    '<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%><%/properties%>}<%/isObject%><%!
+<%#properties%>    '<%name%>'<%^isRequired%>?<%/isRequired%>: <%>type%>;<%/properties%>}<%/isObject%><%!
 
 %><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>><%/isArray%><%!
 


### PR DESCRIPTION
(second try with correct branch)

This repairs the grunt-based tests run with "grunt". The bug occurred in
conjunction with "beautify" option, I think (I never had this bug in my
generated client, because I do not use "beautify" there but a
custom prettification via "prettier")

The other part of the test suite (the jest-based one) will be fixed in next PR.