### PR TITLE
Added method to get data and options from processed swagger spec without generating the code.

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -29,6 +29,12 @@ export const CodeGen = {
     const options = makeOptions(opts);
 
     return enhanceCode(getCode(options), options);
+  },
+  getDataAndOptionsForGeneration: function(opts: ProvidedCodeGenOptions) {
+    const options = makeOptions(opts);
+    verifyThatWeAreGeneratingForSwagger2(options);
+    const data = getViewForSwagger2(options);
+    return { data, options };
   }
 };
 


### PR DESCRIPTION
I'd like to be able to use data from processed swagger spec for custom analysis and, possibly, a different templating engine. For that purpose, it is nice to have a method which returns this data to us. 