### PR TITLE
Fix issue with json spec format: "additionalProperties": false

### DIFF
--- a/src/type-mappers/dictionary.ts
+++ b/src/type-mappers/dictionary.ts
@@ -37,6 +37,7 @@ export function isDictionary(
 ): swaggerType is SwaggerDictionary {
   return (
     swaggerType.type === "object" &&
-    swaggerType.hasOwnProperty("additionalProperties")
+    swaggerType.hasOwnProperty("additionalProperties") &&
+    (swaggerType as any).additionalProperties !== false
   );
 }

--- a/src/typescript.test.ts
+++ b/src/typescript.test.ts
@@ -351,6 +351,23 @@ describe("convertType", () => {
       });
     });
 
+    it("correctly converts an object type with additionalProperties: false", () => {
+      swaggerType = makeSwaggerType({
+        type: "object",
+        additionalProperties: false
+      });
+
+      expect(convertType(swaggerType, swagger)).toEqual({
+        ...emptyTypeSpecWithDefaults,
+        tsType: "object",
+        isAtomic: false,
+        isObject: true,
+        isDictionary: false,
+        properties: [],
+        requiredPropertyNames: []
+      });
+    });
+
     it("handles required properties", () => {
       swaggerType = makeSwaggerType({
         type: "object",


### PR DESCRIPTION
Fixes issue parsing NSwag's json spec output format.
Issue with json spec format: "additionalProperties": false

Input:

```
"ProductDetailsViewModel": {
      "type": "object",
      "additionalProperties": false, // this line
      "properties": {
        "BrandName": {
          "type": "string"
        }
      }
}
```

Expected output:
object type

Actual output:
dictionary type