### PR TITLE
Fix @types/superagent has no default export

### DIFF
--- a/__tests__/__snapshots__/runner.js.snap
+++ b/__tests__/__snapshots__/runner.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Real world: Uber 1`] = `
-"import request, {
+"import * as request from \\"superagent\\";
+import {
     SuperAgentStatic,
     SuperAgentRequest,
     Response
@@ -703,7 +704,8 @@ export default UberApi;"
 `;
 
 exports[`Real world: petshop 1`] = `
-"import request, {
+"import * as request from \\"superagent\\";
+import {
     SuperAgentStatic,
     SuperAgentRequest,
     Response
@@ -2204,7 +2206,8 @@ export default PetshopApi;"
 `;
 
 exports[`Real world: users 1`] = `
-"import request, {
+"import * as request from \\"superagent\\";
+import {
     SuperAgentStatic,
     SuperAgentRequest,
     Response
@@ -2459,7 +2462,8 @@ export default UsersApi;"
 `;
 
 exports[`Should resolve protected api 1`] = `
-"import request, {
+"import * as request from \\"superagent\\";
+import {
     SuperAgentStatic,
     SuperAgentRequest,
     Response
@@ -2772,7 +2776,8 @@ export default ProtectedApi;"
 `;
 
 exports[`Should resolve references 1`] = `
-"import request, {
+"import * as request from \\"superagent\\";
+import {
     SuperAgentStatic,
     SuperAgentRequest,
     Response

--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -2,7 +2,8 @@
 /// <reference path="{{&.}}" />
 {{/imports}}
 
-import request, { SuperAgentStatic, SuperAgentRequest, Response } from "superagent";
+import * as request from "superagent";
+import { SuperAgentStatic, SuperAgentRequest, Response } from "superagent";
 
 export type RequestHeaders = {
     [header: string]: string;


### PR DESCRIPTION
Fix `@types/superagent` has no default export.
Although this might be an issue with the `"@types/superagent": "^4.1.0"` type definition.

With typescript `"strict": true,` config enabled, doesn't allow implicit any type.

```
TS1192: Module '"C:/_/node_modules/@types/superagent/index"' has no default export.

TS7006: Parameter 'error' implicitly has an 'any' type.

TS7006: Parameter 'response' implicitly has an 'any' type.
```