### PR TITLE
Returning correct model for all 2xx responses

### DIFF
--- a/src/swagger/Swagger.ts
+++ b/src/swagger/Swagger.ts
@@ -85,7 +85,7 @@ export interface HttpOperation {
   readonly deprecated: boolean;
   readonly security: boolean;
   readonly responses: {
-    readonly 200: SwaggerType;
+    readonly [index: string]: SwaggerType;
   };
   readonly operationId: string;
   readonly description: string;

--- a/src/view-data/responseType.ts
+++ b/src/view-data/responseType.ts
@@ -1,7 +1,35 @@
 import { convertType } from "../typescript";
-import { HttpOperation, Swagger } from "../swagger/Swagger";
+import { HttpOperation, Swagger, SwaggerType } from "../swagger/Swagger";
 
 const defaultSuccessfulResponseType = "void";
+
+// https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success
+const successfulCodes = [
+  "200", // OK
+  "201", // Created
+  "202", // Accepted
+  "203", // Non-Authoritative Information
+  "204", // No Content
+  "205", // Reset Content
+  "206", // Partial Content
+  "207", // Multi-Status
+  "208", // Already Reported
+  "226" // IM Used
+];
+
+function onlySuccessful(statusCode: string) {
+  return successfulCodes.includes(statusCode);
+}
+
+function getSuccessfulResponse(op: HttpOperation): SwaggerType {
+  const definedSuccessCodes = Object.keys(op.responses).filter(onlySuccessful);
+
+  if (definedSuccessCodes.length === 0) {
+    throw new Error("No success responses defined");
+  }
+
+  return op.responses[definedSuccessCodes[0]];
+}
 
 export function getSuccessfulResponseType(
   op: HttpOperation,
@@ -11,7 +39,8 @@ export function getSuccessfulResponseType(
   let successfulResponseType;
 
   try {
-    const convertedType = convertType(op.responses["200"], swagger);
+    const successfulResponse = getSuccessfulResponse(op);
+    const convertedType = convertType(successfulResponse, swagger);
 
     if (convertedType.target) {
       successfulResponseTypeIsRef = true;


### PR DESCRIPTION
Hello, I've come across an NPM package and started using it, however I found that the client is not returning right models for anything but 200 respones, so I've spent some time putting together a pull request addressing the issue.


Consider this swagger file example

https://gist.github.com/kettlensk/3bab7c7a94738c27915fd5f7818eee6b


```swagger
paths:
  /pet:
    post:
      summary: "Add a new pet to the store"
      operationId: "addPet"
      consumes:
      - "application/json"
      produces:
      - "application/json"
      parameters:
      - in: "body"
        name: "body"
        description: "Pet object that needs to be added to the store"
        required: true
        schema:
          $ref: "#/definitions/Pet"
      responses:
        201:
          description: "Pet Created"
          schema:
            $ref: "#/definitions/Pet"
        405:
          description: "Invalid input"
```


An API call will respond with `201 CREATED` status and freshly created Pet object. To determine returned model current code will look for exact 200 code an ignore 201 here, that will result in generated API client marking this call as returning `void`

However current implementation will end up with follow code for it:

```TypeScript
    /**
     * Add a new pet to the store
     * @method
     * @name Test#addPet
     * @param {} body - Pet object that needs to be added to the store
     */
    addPet(parameters: {
        'body': Pet,
        $queryParameters ? : any,
        $domain ? : string,
        $path ? : string | ((path: string) => string)
    }): Promise < ResponseWithBody < void >> {
```

while new code will produce

```TypeScript
    /**
     * Add a new pet to the store
     * @method
     * @name Test#addPet
     * @param {} body - Pet object that needs to be added to the store
     */
    addPet(parameters: {
        'body': Pet,
        $queryParameters ? : any,
        $domain ? : string,
        $path ? : string | ((path: string) => string)
    }): Promise < ResponseWithBody < Pet >> {
```

Note `Promise < ResponseWithBody < void >>` vs `Promise < ResponseWithBody < Pet >> ` here.


