### PR TITLE
Remove duplicate properties from objects

### DIFF
--- a/src/type-mappers/object.ts
+++ b/src/type-mappers/object.ts
@@ -1,5 +1,13 @@
 import { makeTypeSpecFromSwaggerType, TypeSpec } from "../typespec";
-import { map, filter, flatten, includes, concat, isArray } from "lodash";
+import {
+  map,
+  filter,
+  flatten,
+  includes,
+  concat,
+  isArray,
+  uniqBy
+} from "lodash";
 import { SwaggerType } from "../swagger/Swagger";
 import { Swagger } from "../swagger/Swagger";
 import { convertType } from "../typescript";
@@ -21,9 +29,12 @@ export function makeObjectTypeSpec(
     swaggerType.type === "object" && isArray(swaggerType.required)
       ? swaggerType.required
       : [];
-  const properties = concat(
-    getAllOfProperties(swaggerType, swagger),
-    getObjectProperties(swaggerType, swagger, requiredPropertyNames)
+  const properties = uniqBy(
+    concat(
+      getAllOfProperties(swaggerType, swagger),
+      getObjectProperties(swaggerType, swagger, requiredPropertyNames)
+    ),
+    "name"
   );
 
   return {

--- a/src/type-mappers/object.ts
+++ b/src/type-mappers/object.ts
@@ -6,7 +6,8 @@ import {
   includes,
   concat,
   isArray,
-  uniqBy
+  uniqBy,
+  reverse
 } from "lodash";
 import { SwaggerType } from "../swagger/Swagger";
 import { Swagger } from "../swagger/Swagger";
@@ -29,13 +30,16 @@ export function makeObjectTypeSpec(
     swaggerType.type === "object" && isArray(swaggerType.required)
       ? swaggerType.required
       : [];
-  const properties = uniqBy(
-    concat(
-      getAllOfProperties(swaggerType, swagger),
-      getObjectProperties(swaggerType, swagger, requiredPropertyNames)
-    ),
-    "name"
+
+  // Some special handling is needed to support overlapping properties. The list of properties must be reversed to get the
+  // overriding properties first. Only then can we filter out any duplicates. To get the original order back, the array
+  // is reversed once more
+  const allProperties = concat(
+    getAllOfProperties(swaggerType, swagger),
+    getObjectProperties(swaggerType, swagger, requiredPropertyNames)
   );
+  const uniqueProperties = uniqBy(reverse(allProperties), "name");
+  const properties = reverse(uniqueProperties);
 
   return {
     ...makeTypeSpecFromSwaggerType(swaggerType),

--- a/tests/apis/allOf.json
+++ b/tests/apis/allOf.json
@@ -1,0 +1,36 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "API"
+  },
+  "paths": {},
+  "definitions": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rank": {
+          "type": "number"
+        }
+      }
+    },
+    "Bar": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Foo"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "rank": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I noticed that generated code can have duplicate properties in case `allOf` section also includes a reference to an object that has the same properties.

I hope my ad-hoc fix is okay!

Regards,
Andreas