### PR TITLE
Add option to generate code for deprecated methods

### DIFF
--- a/src/getViewForSwagger2.ts
+++ b/src/getViewForSwagger2.ts
@@ -12,7 +12,8 @@ import {
 } from "./view-data/definition";
 import {
   getHttpMethodTuplesFromSwaggerPathsObject,
-  isAuthorizedAndNotDeprecated
+  isAuthorizedAndNotDeprecated,
+  isAuthorizedMethod
 } from "./view-data/operation";
 
 export type GenerationTargetType = "typescript" | "custom";
@@ -93,7 +94,11 @@ const makeMethodsFromPaths = (
   swagger: Swagger
 ): Method[] =>
   getHttpMethodTuplesFromSwaggerPathsObject(swagger.paths)
-    .filter(isAuthorizedAndNotDeprecated)
+    .filter(
+      method =>
+        (opts.includeDeprecated && isAuthorizedMethod(method)) ||
+        isAuthorizedAndNotDeprecated(method)
+    )
     .map(([path, httpVerb, op, globalParams]) => {
       // TODO: Start of untested security stuff that needs fixing
       const secureTypes = [];

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -5,6 +5,7 @@ import { Swagger } from "../swagger/Swagger";
 const defaultOptions = {
   isES6: false,
   moduleName: "",
+  includeDeprecated: false,
   imports: [],
   className: "",
   template: {},

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -10,6 +10,7 @@ export interface TemplateLocations {
 interface Options {
   readonly isES6: boolean;
   readonly moduleName: string;
+  readonly includeDeprecated: boolean;
   readonly imports: ReadonlyArray<string>;
   readonly className: string;
   readonly template: Partial<TemplateLocations>;
@@ -25,6 +26,7 @@ interface SwaggerOption {
 const DEFAULT_OPTIONS: Options = {
   isES6: false,
   moduleName: "",
+  includeDeprecated: false,
   imports: [],
   className: "",
   template: {},

--- a/src/view-data/method.ts
+++ b/src/view-data/method.ts
@@ -23,6 +23,7 @@ export interface Method {
   readonly method: string;
   readonly isGET: boolean;
   readonly isPOST: boolean;
+  readonly isDeprecated: boolean;
   readonly summary: string;
   readonly externalDocs: string;
   readonly parameters: TypeSpecParameter[];
@@ -58,6 +59,7 @@ export function makeMethod(
     method: httpVerb.toUpperCase(),
     isGET: httpVerb.toUpperCase() === "GET",
     isPOST: httpVerb.toUpperCase() === "POST",
+    isDeprecated: op.deprecated,
     summary: op.description || op.summary,
     externalDocs: op.externalDocs,
     isSecure: swagger.security !== undefined || op.security !== undefined,

--- a/src/view-data/operation.ts
+++ b/src/view-data/operation.ts
@@ -67,7 +67,7 @@ const authorizedMethods = [
   "UNLOCK",
   "PROPFIND"
 ];
-const isAuthorizedMethod = ([
+export const isAuthorizedMethod = ([
   _path,
   httpVerb
 ]: PathAndMethodTupleWithPathParams): boolean =>

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -56,6 +56,9 @@
 /**
 * {{&summary}}
 * @method
+{{#isDeprecated}}
+* @deprecated
+{{/isDeprecated}}
 {{#externalDocs}}
 * @see {@link {{&url}}|{{#description}}{{&description}}{{/description}}{{^description}}External docs{{/description}}}
 {{/externalDocs}}


### PR DESCRIPTION
To retain backwards compatibility, deprecated methods are not generated by default.
Fixes #70