### PR TITLE
fix issue with `superagent` initialization

### DIFF
--- a/__tests__/__snapshots__/runner.js.snap
+++ b/__tests__/__snapshots__/runner.js.snap
@@ -124,8 +124,8 @@ export class UberApi {
         }
 
         const agent = this.configureAgentHandler ?
-            this.configureAgentHandler(request) :
-            request;
+            this.configureAgentHandler(request.default) :
+            request.default;
 
         let req = agent(method, url);
         if (this.configureRequestHandler) {
@@ -832,8 +832,8 @@ export class PetshopApi {
         }
 
         const agent = this.configureAgentHandler ?
-            this.configureAgentHandler(request) :
-            request;
+            this.configureAgentHandler(request.default) :
+            request.default;
 
         let req = agent(method, url);
         if (this.configureRequestHandler) {
@@ -2288,8 +2288,8 @@ export class UsersApi {
         }
 
         const agent = this.configureAgentHandler ?
-            this.configureAgentHandler(request) :
-            request;
+            this.configureAgentHandler(request.default) :
+            request.default;
 
         let req = agent(method, url);
         if (this.configureRequestHandler) {
@@ -2562,8 +2562,8 @@ export class ProtectedApi {
         }
 
         const agent = this.configureAgentHandler ?
-            this.configureAgentHandler(request) :
-            request;
+            this.configureAgentHandler(request.default) :
+            request.default;
 
         let req = agent(method, url);
         if (this.configureRequestHandler) {
@@ -2860,8 +2860,8 @@ export class RefApi {
         }
 
         const agent = this.configureAgentHandler ?
-            this.configureAgentHandler(request) :
-            request;
+            this.configureAgentHandler(request.default) :
+            request.default;
 
         let req = agent(method, url);
         if (this.configureRequestHandler) {

--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -79,8 +79,8 @@ export class {{&className}} {
         }
 
         const agent = this.configureAgentHandler
-            ? this.configureAgentHandler(request)
-            : request;
+            ? this.configureAgentHandler(request.default)
+            : request.default;
 
         let req = agent(method, url);
         if (this.configureRequestHandler) {


### PR DESCRIPTION
fix the following issue:

```text
SwaggerTest.ts(432,40): error TS2345: Argument of type '{ default: SuperAgentStatic; agent(): SuperAgentStatic & Request; serialize: { [type: string]: Serializer; }; parse: { [type: string]: Parser; }; jar: CookieJar; attachCookies(req: SuperAgentRequest): void; ... 26 more ...; unsubscribe(url: string, callback?: CallbackHandler | undefined): SuperAgentRequest; }' is not assignable to parameter of type 'SuperAgentStatic'.
  Type '{ default: SuperAgentStatic; agent(): SuperAgentStatic & Request; serialize: { [type: string]: Serializer; }; parse: { [type: string]: Parser; }; jar: CookieJar; attachCookies(req: SuperAgentRequest): void; ... 26 more ...; unsubscribe(url: string, callback?: CallbackHandler | undefined): SuperAgentRequest; }' is missing the following properties from type 'SuperAgentStatic': pipe, addListener, on, once, and 12 more.
```

by using `request.default`.