### PR TITLE
add support for `response refs`

### DIFF
--- a/src/swagger/Swagger.ts
+++ b/src/swagger/Swagger.ts
@@ -144,6 +144,9 @@ export interface Swagger {
   readonly parameters: {
     readonly [index: string]: Parameter;
   };
+  readonly responses?: {
+    readonly [index: string]: SwaggerType;
+  };
   readonly produces: ReadonlyArray<string>;
   readonly consumes: ReadonlyArray<string>;
 }

--- a/tests/apis/test.json
+++ b/tests/apis/test.json
@@ -12,7 +12,7 @@
         "/Users/{id}": {
             "head": {
                 "tags": ["User"],
-                "summary": "Check whether a model instance exists in the data source.",
+                "summary": "Check whether a user instance exists in the data source.",
                 "externalDocs": {
                     "description": "More info on the WIKI",
                     "url": "https://example.atlassian.net/wiki/pages/example"
@@ -21,10 +21,9 @@
                 "parameters": [{
                     "name": "id",
                     "in": "path",
-                    "description": "Model id",
+                    "description": "User id",
                     "required": true,
-                    "type": "string",
-                    "format": "JSON"
+                    "type": "string"
                 }],
                 "responses": {
                     "200": {
@@ -36,8 +35,41 @@
                 },
                 "deprecated": false
             }
+        },
+
+        "/Admins/{id}": {
+            "get": {
+                "tags": ["User"],
+                "summary": "Returns the details for the requested admin user.",
+                "externalDocs": {
+                    "description": "More info on the WIKI",
+                    "url": "https://example.atlassian.net/wiki/pages/example"
+                },
+                "operationId": "User.get_Admin_{id}",
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Admin id",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/get_admin_200"
+                    }
+                },
+                "deprecated": false
+            }
         }
-   },
+    },
+    "responses": {
+        "get_admin_200": {
+            "description": "Admin user details",
+            "schema": {
+                "$ref": "#/definitions/User"
+            }
+        }
+    },
     "definitions": {
         "xany": {
             "properties": {}


### PR DESCRIPTION
The swagger spec allows to define an optional root level `responses` object which allows to reuse `response` definitions for several endpoints; see: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields

This PR adds support for this potential additional level of indirection.

Check the added endpoint def for `/Admin/{id}` in `tests/apis/test.json`. It contains this reference to a shared `response` definition:
```
    "responses": {
        "200": {
            "$ref": "#/responses/get_admin_200"
        }
    }
```
which is pointing to this `response` definition on the root level:
```
    "responses": {
        "get_admin_200": {
            "description": "Admin user details",
            "schema": {
                "$ref": "#/definitions/User"
            }
        }
    }
```