### PR TITLE
Handle case where '/' is an endpoint

### DIFF
--- a/src/view-data/method.ts
+++ b/src/view-data/method.ts
@@ -113,9 +113,10 @@ function getPathToMethodName(httpVerb: string, path: string): string {
   });
 
   const result = camelCase(segments.join("-"));
-  return `${httpVerb.toLowerCase()}${result[0].toUpperCase()}${result.substring(
-    1
-  )}`;
+  if(result.length > 0)
+    return `${httpVerb.toLowerCase()}${result[0].toUpperCase()}${result.substring(1)}`;
+  else
+    return "root";
 }
 
 const groupMethodsByMethodName = (methods: Method[]): Method[][] =>


### PR DESCRIPTION
Handle case where '/' is an endpoint. Without this, result[0] will be undefined.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/105)