### PR TITLE
Refactor codegen.ts

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,7 +1,7 @@
 import {
   ProvidedCodeGenOptions,
   makeOptions,
-  validOptions
+  validateOptions
 } from "./options/options";
 import { transformToCodeWithMustache } from "./transform/transformToCodeWithMustache";
 import { Swagger2Gen } from "./generators/swagger2";
@@ -16,7 +16,7 @@ export const CodeGen = {
     return enhanceCode(Swagger2Gen.getCode(options), options);
   },
   getCustomCode: function(opts: ProvidedCodeGenOptions) {
-    validOptions(opts);
+    validateOptions(opts);
 
     const options = makeOptions(opts);
 

--- a/src/generators/codeGenerator.ts
+++ b/src/generators/codeGenerator.ts
@@ -1,0 +1,25 @@
+import { CodeGenOptions } from "../options/options";
+import { ViewData } from "../getViewForSwagger2";
+
+/**
+ * Abstraction over a code generator.
+ */
+export interface CodeGenerator {
+  /**
+   * Returns the ViewData from the provided options.
+   *
+   * @param {CodeGenOptions} opts
+   *
+   * @returns {ViewData}
+   */
+  getViewData(opts: CodeGenOptions): ViewData;
+
+  /**
+   * Generate the code from the provided options.
+   *
+   * @param {CodeGenOptions} opts
+   *
+   * @returns {string}
+   */
+  getCode(opts: CodeGenOptions): string;
+}

--- a/src/generators/swagger2.ts
+++ b/src/generators/swagger2.ts
@@ -1,0 +1,26 @@
+import { CodeGenOptions } from "../options/options";
+import { transformToCodeWithMustache } from "../transform/transformToCodeWithMustache";
+import { getViewForSwagger2, ViewData } from "../getViewForSwagger2";
+
+interface CodeGenerator {
+  getViewData(opts: CodeGenOptions): ViewData;
+  getCode(opts: CodeGenOptions): string;
+}
+
+function verifyThatWeAreGeneratingForSwagger2(opts: CodeGenOptions): void {
+  if (opts.swagger.swagger !== "2.0") {
+    throw new Error("Only Swagger 2 specs are supported");
+  }
+}
+
+export const Swagger2Gen: CodeGenerator = {
+  getViewData: function(opts: CodeGenOptions): ViewData {
+    verifyThatWeAreGeneratingForSwagger2(opts);
+
+    return getViewForSwagger2(opts);
+  },
+  getCode: function(opts: CodeGenOptions): string {
+    const data = this.getViewData(opts);
+    return transformToCodeWithMustache(data, opts.template, opts.mustache);
+  }
+};

--- a/src/generators/swagger2.ts
+++ b/src/generators/swagger2.ts
@@ -1,6 +1,6 @@
 import { CodeGenOptions } from "../options/options";
 import { transformToCodeWithMustache } from "../transform/transformToCodeWithMustache";
-import { getViewForSwagger2, ViewData } from "../getViewForSwagger2";
+import { getViewForSwagger2 } from "../getViewForSwagger2";
 import { CodeGenerator } from "./codeGenerator";
 
 function verifyThatWeAreGeneratingForSwagger2(opts: CodeGenOptions): void {
@@ -16,7 +16,7 @@ export const Swagger2Gen: CodeGenerator = {
     return getViewForSwagger2(opts);
   },
   getCode: opts => {
-    const data = this.getViewData(opts);
+    const data = Swagger2Gen.getViewData(opts);
     return transformToCodeWithMustache(data, opts.template, opts.mustache);
   }
 };

--- a/src/generators/swagger2.ts
+++ b/src/generators/swagger2.ts
@@ -1,11 +1,7 @@
 import { CodeGenOptions } from "../options/options";
 import { transformToCodeWithMustache } from "../transform/transformToCodeWithMustache";
 import { getViewForSwagger2, ViewData } from "../getViewForSwagger2";
-
-interface CodeGenerator {
-  getViewData(opts: CodeGenOptions): ViewData;
-  getCode(opts: CodeGenOptions): string;
-}
+import { CodeGenerator } from "./codeGenerator";
 
 function verifyThatWeAreGeneratingForSwagger2(opts: CodeGenOptions): void {
   if (opts.swagger.swagger !== "2.0") {

--- a/src/generators/swagger2.ts
+++ b/src/generators/swagger2.ts
@@ -10,12 +10,12 @@ function verifyThatWeAreGeneratingForSwagger2(opts: CodeGenOptions): void {
 }
 
 export const Swagger2Gen: CodeGenerator = {
-  getViewData: function(opts: CodeGenOptions): ViewData {
+  getViewData: opts => {
     verifyThatWeAreGeneratingForSwagger2(opts);
 
     return getViewForSwagger2(opts);
   },
-  getCode: function(opts: CodeGenOptions): string {
+  getCode: opts => {
     const data = this.getViewData(opts);
     return transformToCodeWithMustache(data, opts.template, opts.mustache);
   }

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -1,4 +1,4 @@
-import { makeOptions } from "./options";
+import { makeOptions, validateOptions } from "./options";
 import * as Mustache from "mustache";
 import { Swagger } from "../swagger/Swagger";
 
@@ -35,5 +35,53 @@ describe("makeOptions", () => {
     const options = makeOptions(partialOptions);
 
     expect(options.className).toBe("GeneratedDataLayer");
+  });
+});
+
+describe("validateOptions", () => {
+  it("with valid options", () => {
+    const partialOptions = {
+      swagger: {} as Swagger,
+      template: {
+        class: "class-template",
+        method: "method-template"
+      }
+    };
+
+    const options = makeOptions(partialOptions);
+
+    expect(() => validateOptions(options));
+  });
+
+  it("throws when class template is not provided", () => {
+    const partialOptions = {
+      swagger: {} as Swagger,
+      template: {
+        class: "class-template",
+        method: undefined
+      }
+    };
+
+    const options = makeOptions(partialOptions);
+
+    expect(() => validateOptions(options)).toThrow(
+      'Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }'
+    );
+  });
+
+  it("throws when method template is not provided", () => {
+    const partialOptions = {
+      swagger: {} as Swagger,
+      template: {
+        class: undefined,
+        method: "method-template"
+      }
+    };
+
+    const options = makeOptions(partialOptions);
+
+    expect(() => validateOptions(options)).toThrow(
+      'Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }'
+    );
   });
 });

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,4 +1,5 @@
 import * as Mustache from "mustache";
+import { isObject, isString } from "lodash";
 import { Swagger } from "../swagger/Swagger";
 
 export interface TemplateLocations {
@@ -47,4 +48,21 @@ export function makeOptions(options: ProvidedCodeGenOptions): CodeGenOptions {
     ...DEFAULT_OPTIONS,
     ...options
   };
+}
+
+/**
+ * Validate that the options have required variables for custom generation.
+ */
+export function validOptions(options: ProvidedCodeGenOptions): void {
+  // TODO: Why do we not check for the existence of the type template?
+  if (
+    !options.template ||
+    !isObject(options.template) ||
+    !isString(options.template.class) ||
+    !isString(options.template.method)
+  ) {
+    throw new Error(
+      'Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }'
+    );
+  }
 }

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -53,7 +53,7 @@ export function makeOptions(options: ProvidedCodeGenOptions): CodeGenOptions {
 /**
  * Validate that the options have required variables for custom generation.
  */
-export function validOptions(options: ProvidedCodeGenOptions): void {
+export function validateOptions(options: ProvidedCodeGenOptions): void {
   // TODO: Why do we not check for the existence of the type template?
   if (
     !options.template ||


### PR DESCRIPTION
Splitting out the not exported code from codegen.ts to make it easier to read.

There are a few exported methods in `CodeGen` that I don't really see a good use, I didn't want to remove anything for compatibility.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/110)