### PR TITLE
Rename 'TemplateLocations' to 'OptionTemplates'

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,7 +1,7 @@
 import * as Mustache from "mustache";
 import { Swagger } from "../swagger/Swagger";
 
-export interface TemplateLocations {
+export interface OptionTemplates {
   readonly class: string;
   readonly method: string;
   readonly type: string;
@@ -13,7 +13,7 @@ interface Options {
   readonly includeDeprecated: boolean;
   readonly imports: ReadonlyArray<string>;
   readonly className: string;
-  readonly template: Partial<TemplateLocations>;
+  readonly template: Partial<OptionTemplates>;
   readonly mustache: typeof Mustache;
   readonly beautify: ((source: string) => string) | boolean;
   readonly beautifyOptions: JsBeautifyOptions;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,7 +1,7 @@
 import * as Mustache from "mustache";
 import { Swagger } from "../swagger/Swagger";
 
-export interface OptionTemplates {
+export interface Template {
   readonly class: string;
   readonly method: string;
   readonly type: string;
@@ -13,7 +13,7 @@ interface Options {
   readonly includeDeprecated: boolean;
   readonly imports: ReadonlyArray<string>;
   readonly className: string;
-  readonly template: Partial<OptionTemplates>;
+  readonly template: Partial<Template>;
   readonly mustache: typeof Mustache;
   readonly beautify: ((source: string) => string) | boolean;
   readonly beautifyOptions: JsBeautifyOptions;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -35,13 +35,21 @@ const DEFAULT_OPTIONS: Options = {
   beautifyOptions: {}
 };
 
-// This is the internal interface we use to reference to the full Options object with defaults
+/**
+ * This is the internal interface we use to reference to the full Options object with defaults
+ */
 export interface CodeGenOptions extends Options, SwaggerOption {}
-// All options except the swagger object are optional when passing in options
+
+/**
+ * All options except the swagger object are optional when passing in options
+ */
 export interface ProvidedCodeGenOptions
   extends Partial<Options>,
     SwaggerOption {}
 
+/**
+ * Merge passed options with the default options.
+ */
 export function makeOptions(options: ProvidedCodeGenOptions): CodeGenOptions {
   return {
     ...DEFAULT_OPTIONS,

--- a/src/transform/transformToCodeWithMustache.ts
+++ b/src/transform/transformToCodeWithMustache.ts
@@ -2,12 +2,12 @@ import { readFileSync } from "fs";
 import * as Mustache from "mustache";
 import {} from "mustache";
 import { assign, identity } from "lodash";
-import { TemplateLocations } from "../options/options";
+import { OptionTemplates } from "../options/options";
 import { join } from "path";
 
 export const DEFAULT_TEMPLATE_PATH = join(__dirname, "..", "..", "templates");
 
-export type Templates = Record<keyof TemplateLocations, string>;
+export type Templates = Record<keyof OptionTemplates, string>;
 
 type Renderer = {
   readonly render: (

--- a/src/transform/transformToCodeWithMustache.ts
+++ b/src/transform/transformToCodeWithMustache.ts
@@ -2,12 +2,12 @@ import { readFileSync } from "fs";
 import * as Mustache from "mustache";
 import {} from "mustache";
 import { assign, identity } from "lodash";
-import { OptionTemplates } from "../options/options";
+import { Template } from "../options/options";
 import { join } from "path";
 
 export const DEFAULT_TEMPLATE_PATH = join(__dirname, "..", "..", "templates");
 
-export type Templates = Record<keyof OptionTemplates, string>;
+export type Templates = Record<keyof Template, string>;
 
 type Renderer = {
   readonly render: (
@@ -37,16 +37,16 @@ export function transformToCodeWithMustache<T, C extends {}>(
   );
 }
 
-function loadTemplates(templateLocations: Partial<Templates> = {}): Templates {
+function loadTemplates(template: Partial<Templates> = {}): Templates {
   return {
     class:
-      templateLocations.class ||
+      template.class ||
       readFileSync(join(DEFAULT_TEMPLATE_PATH, "class.mustache"), "utf-8"),
     method:
-      templateLocations.method ||
+      template.method ||
       readFileSync(join(DEFAULT_TEMPLATE_PATH, "method.mustache"), "utf-8"),
     type:
-      templateLocations.type ||
+      template.type ||
       readFileSync(join(DEFAULT_TEMPLATE_PATH, "type.mustache"), "utf-8")
   };
 }


### PR DESCRIPTION
The properties inside `TemplateLocations` are not locations, it's the full file content.

It would be nice to change it to be file locations, but that would not be very nice for compatibility.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/111)