### PR TITLE
Use lower case default headers

### DIFF
--- a/__tests__/__snapshots__/runner.js.snap
+++ b/__tests__/__snapshots__/runner.js.snap
@@ -153,6 +153,14 @@ export class UberApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -165,14 +173,6 @@ export class UberApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -1006,6 +1006,14 @@ export class PetshopApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -1018,14 +1026,6 @@ export class PetshopApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -2590,6 +2590,14 @@ export class UsersApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -2602,14 +2610,6 @@ export class UsersApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -2973,6 +2973,14 @@ export class AddpropsApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -2985,14 +2993,6 @@ export class AddpropsApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -3194,6 +3194,14 @@ export class CollectionformatApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -3206,14 +3214,6 @@ export class CollectionformatApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -3540,6 +3540,14 @@ export class ProtectedApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -3552,14 +3560,6 @@ export class ProtectedApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -3908,6 +3908,14 @@ export class RefApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -3920,14 +3928,6 @@ export class RefApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -4189,6 +4189,14 @@ export class ResponsesApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -4201,14 +4209,6 @@ export class ResponsesApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);
@@ -4404,6 +4404,14 @@ export class RootpathApi {
 
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({
+                ...headers
+            });
+        }
+
+        req.set(headers);
+
         if (body) {
             req.send(body);
 
@@ -4416,14 +4424,6 @@ export class RootpathApi {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({
-                ...headers
-            });
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);

--- a/__tests__/__snapshots__/runner.js.snap
+++ b/__tests__/__snapshots__/runner.js.snap
@@ -157,7 +157,7 @@ export class UberApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -275,7 +275,7 @@ export class UberApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             if (parameters['latitude'] !== undefined) {
                 queryParameters['latitude'] = this.convertParameterCollectionFormat(
@@ -380,7 +380,7 @@ export class UberApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             path = path.replace(
                 '{id}',
@@ -508,7 +508,7 @@ export class UberApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             if (parameters['startLatitude'] !== undefined) {
                 queryParameters['start_latitude'] = this.convertParameterCollectionFormat(
@@ -647,7 +647,7 @@ export class UberApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             if (parameters['startLatitude'] !== undefined) {
                 queryParameters['start_latitude'] = this.convertParameterCollectionFormat(
@@ -734,7 +734,7 @@ export class UberApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             if (parameters.$queryParameters) {
                 queryParameters = {
@@ -805,7 +805,7 @@ export class UberApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             if (parameters['offset'] !== undefined) {
                 queryParameters['offset'] = this.convertParameterCollectionFormat(
@@ -1010,7 +1010,7 @@ export class PetshopApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -1113,8 +1113,8 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
-            headers['Content-Type'] = 'application/json';
+            headers['accept'] = 'application/xml, application/json';
+            headers['content-type'] = 'application/json';
 
             if (parameters['body'] !== undefined) {
                 body = parameters['body'];
@@ -1180,8 +1180,8 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
-            headers['Content-Type'] = 'application/json';
+            headers['accept'] = 'application/xml, application/json';
+            headers['content-type'] = 'application/json';
 
             if (parameters['body'] !== undefined) {
                 body = parameters['body'];
@@ -1253,7 +1253,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['status'] !== undefined) {
                 queryParameters['status'] = this.convertParameterCollectionFormat(
@@ -1327,7 +1327,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             path = path.replace(
                 '{petId}',
@@ -1410,8 +1410,8 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
-            headers['Content-Type'] = 'application/x-www-form-urlencoded';
+            headers['accept'] = 'application/xml, application/json';
+            headers['content-type'] = 'application/x-www-form-urlencoded';
 
             path = path.replace(
                 '{petId}',
@@ -1500,7 +1500,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['apiKey'] !== undefined) {
                 headers['api_key'] = parameters['apiKey'];
@@ -1587,8 +1587,8 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'multipart/form-data';
+            headers['accept'] = 'application/json';
+            headers['content-type'] = 'multipart/form-data';
 
             path = path.replace(
                 '{petId}',
@@ -1661,7 +1661,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/json';
+            headers['accept'] = 'application/json';
 
             if (parameters.$queryParameters) {
                 queryParameters = {
@@ -1717,7 +1717,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['body'] !== undefined) {
                 body = parameters['body'];
@@ -1791,7 +1791,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             path = path.replace(
                 '{orderId}',
@@ -1866,7 +1866,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             path = path.replace(
                 '{orderId}',
@@ -1935,7 +1935,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['body'] !== undefined) {
                 body = parameters['body'];
@@ -2005,7 +2005,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['body'] !== undefined) {
                 body = parameters['body'];
@@ -2075,7 +2075,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['body'] !== undefined) {
                 body = parameters['body'];
@@ -2158,7 +2158,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters['username'] !== undefined) {
                 queryParameters['username'] = this.convertParameterCollectionFormat(
@@ -2231,7 +2231,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             if (parameters.$queryParameters) {
                 queryParameters = {
@@ -2293,7 +2293,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             path = path.replace(
                 '{username}',
@@ -2371,7 +2371,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             path = path.replace(
                 '{username}',
@@ -2455,7 +2455,7 @@ export class PetshopApi {
         let headers: RequestHeaders = {};
         let form: any = {};
         return new Promise((resolve, reject) => {
-            headers['Accept'] = 'application/xml, application/json';
+            headers['accept'] = 'application/xml, application/json';
 
             path = path.replace(
                 '{username}',
@@ -2594,7 +2594,7 @@ export class UsersApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -2977,7 +2977,7 @@ export class AddpropsApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -3198,7 +3198,7 @@ export class CollectionformatApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -3544,7 +3544,7 @@ export class ProtectedApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -3912,7 +3912,7 @@ export class RefApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -4193,7 +4193,7 @@ export class ResponsesApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 
@@ -4408,7 +4408,7 @@ export class RootpathApi {
             req.send(body);
 
             if (typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 

--- a/src/view-data/headers.ts
+++ b/src/view-data/headers.ts
@@ -11,7 +11,7 @@ export function getHeadersForMethod(
 
   if (produces) {
     headers.push({
-      name: "Accept",
+      name: "accept",
       value: `'${produces.join(", ")}'`
     });
   }
@@ -19,7 +19,7 @@ export function getHeadersForMethod(
   const consumes = op.consumes || swagger.consumes;
   if (consumes) {
     const preferredContentType = consumes[0] || "";
-    headers.push({ name: "Content-Type", value: `'${preferredContentType}'` });
+    headers.push({ name: "content-type", value: `'${preferredContentType}'` });
   }
 
   return headers;

--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -100,7 +100,7 @@ export class {{&className}} {
             req.send(body);
         
             if(typeof(body) === 'object' && !(body.constructor.name === 'Buffer')) {
-                headers['Content-Type'] = 'application/json';
+                headers['content-type'] = 'application/json';
             }
         }
 

--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -96,6 +96,12 @@ export class {{&className}} {
      
         req = req.query(queryParameters);
 
+        if (this.requestHeadersHandler) {
+            headers = this.requestHeadersHandler({...headers});
+        }
+
+        req.set(headers);
+
         if(body) {
             req.send(body);
         
@@ -108,12 +114,6 @@ export class {{&className}} {
             req.type('form');
             req.send(form);
         }
-
-        if (this.requestHeadersHandler) {
-            headers = this.requestHeadersHandler({...headers});
-        }
-
-        req.set(headers);
 
         if (opts.$retries && opts.$retries > 0) {
             req.retry(opts.$retries);


### PR DESCRIPTION
When using `produces` or `consumes` in the swagger description there's currently a case mismatch between the casing of the code generator and superagent.

In my specific case, I have an endpoint consuming `text/csv`. Apparently, the body is of type `string`.

Internally, when sending a string to the endpoint `res.send(body)` is called. In the `send` method, superagent gets the `content-type` header (lower case, [see here](https://github.com/visionmedia/superagent/blob/c7a10e2b51609705936cfcb5bc1bd8a40e8fe1cb/src/request-base.js#L594)).

If it doesn't find it, the content type is overriden and set to `application/x-www-form-urlencoded`. Thus, my string body is sent as `[object Object]` to the backend because the content is transformed. This [happens here](https://github.com/visionmedia/superagent/blob/c7a10e2b51609705936cfcb5bc1bd8a40e8fe1cb/src/request-base.js#L620-L623).

If somebody considers this as a breaking change, I would also be happy by introducing a `lowerCaseName` field which then can be used in mustache files. However, I think sticking to the lower case header names convention of superagent is the better way to solve the issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/116)