### PR TITLE
Fix an error when swagger type is object, but doesn't have the type attribute

### DIFF
--- a/__tests__/__snapshots__/runner.js.snap
+++ b/__tests__/__snapshots__/runner.js.snap
@@ -27,6 +27,8 @@ export type Product = {
     'display_name' ? : string;
     'capacity' ? : string;
     'image' ? : string;
+} & {
+    [key: string]: any;
 };
 
 export type PriceEstimate = {
@@ -37,6 +39,8 @@ export type PriceEstimate = {
     'low_estimate' ? : number;
     'high_estimate' ? : number;
     'surge_multiplier' ? : number;
+} & {
+    [key: string]: any;
 };
 
 export type Profile = {
@@ -45,10 +49,14 @@ export type Profile = {
     'email' ? : string;
     'picture' ? : string;
     'promo_code' ? : string;
+} & {
+    [key: string]: any;
 };
 
 export type Activity = {
     'uuid' ? : string;
+} & {
+    [key: string]: any;
 };
 
 export type Activities = {
@@ -56,12 +64,16 @@ export type Activities = {
     'limit' ? : number;
     'count' ? : number;
     'history' ? : Activity;
+} & {
+    [key: string]: any;
 };
 
 export type Error = {
     'code' ? : number;
     'message' ? : string;
     'fields' ? : string;
+} & {
+    [key: string]: any;
 };
 
 export type Response_getProducts_200 = Array < Product >
@@ -3447,20 +3459,24 @@ export type ConfigureRequestHandler = (agent: SuperAgentRequest) => SuperAgentRe
 export type CallbackHandler = (err: any, res ? : request.Response) => void;
 
 export type Authentication = {
-    'token_type' ? : \\"bearer\\";
-    'expiration_date' ? : {};
-    'access_token' ? : string;
-    'refresh_token' ? : string;
-    'project_tokens' ? : {};
+    'token_type': \\"bearer\\";
+    'expiration_date': {};
+    'access_token': string;
+    'refresh_token': string;
+    'project_tokens': {};
+} & {
+    [key: string]: any;
 };
 
 export type Error = {
-    'code' ? : string;
-    'message' ? : string;
+    'code': string;
+    'message': string;
     'description' ? : string;
     'module' ? : string;
     'line-number' ? : string;
     'column-number' ? : string;
+} & {
+    [key: string]: any;
 };
 
 export type Logger = {

--- a/src/getViewForSwagger2.test.ts
+++ b/src/getViewForSwagger2.test.ts
@@ -79,20 +79,19 @@ describe("getViewForSwagger2", () => {
         }
       });
       const view = getViewForSwagger2(options);
-      console.log(JSON.stringify(view.definitions));
       expect(view.definitions.length).toEqual(1);
       expect(view.definitions[0].tsType).toEqual(
-        expect.objectContaining({ isRequired: true })
+        expect.objectContaining({ isRequired: true }) //this still confuses me
       );
       expect(view.definitions[0].tsType.properties).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: "anyProperty",
-            isRequired: false // should be true
+            isRequired: true
           }),
           expect.objectContaining({
             name: "anotherProperty",
-            isRequired: false // should be true
+            isRequired: true
           }),
           expect.objectContaining({
             name: "notRequiredProperty",

--- a/src/getViewForSwagger2.test.ts
+++ b/src/getViewForSwagger2.test.ts
@@ -54,6 +54,55 @@ describe("getViewForSwagger2", () => {
     expect(getViewForSwagger2(options)).toEqual(makeViewData({}));
   });
 
+  describe("should map objects correctly", () => {
+    it("can handle required properties", () => {
+      const options = makeOptions({
+        swagger: {
+          ...swagger,
+          definitions: {
+            typeWithRequiredProperties: {
+              minItems: 0,
+              required: ["anyProperty", "anotherProperty"],
+              properties: {
+                anyProperty: {
+                  type: "string"
+                },
+                anotherProperty: {
+                  type: "string"
+                },
+                notRequiredProperty: {
+                  type: "string"
+                }
+              }
+            }
+          } as any
+        }
+      });
+      const view = getViewForSwagger2(options);
+      console.log(JSON.stringify(view.definitions));
+      expect(view.definitions.length).toEqual(1);
+      expect(view.definitions[0].tsType).toEqual(
+        expect.objectContaining({ isRequired: true })
+      );
+      expect(view.definitions[0].tsType.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "anyProperty",
+            isRequired: false // should be true
+          }),
+          expect.objectContaining({
+            name: "anotherProperty",
+            isRequired: false // should be true
+          }),
+          expect.objectContaining({
+            name: "notRequiredProperty",
+            isRequired: false
+          })
+        ])
+      );
+    });
+  });
+
   describe("should honor includeDeprecated option", () => {
     let deprecatedSwagger: Swagger;
 

--- a/src/type-mappers/object.ts
+++ b/src/type-mappers/object.ts
@@ -56,8 +56,10 @@ export function makeObjectTypeSpec(
   swagger: Swagger
 ): ObjectTypeSpec {
   // TODO: We threat everything that reaches this point as an object but not the required properties? (Removing the check for object makes the tests fail)
+  // NOTE: object might not be set, because everything without a type is treated as object.
   const requiredPropertyNames =
-    swaggerType.type === "object" && isArray(swaggerType.required)
+    (!swaggerType.type || swaggerType.type === "object") &&
+    isArray(swaggerType.required)
       ? swaggerType.required
       : [];
 

--- a/src/type-mappers/object.ts
+++ b/src/type-mappers/object.ts
@@ -29,7 +29,7 @@ export function extractAdditionalPropertiesType(
   swaggerType: SwaggerType,
   swagger: Swagger
 ): TypeSpec | undefined {
-  if (swaggerType.type !== "object") {
+  if (swaggerType.type && swaggerType.type !== "object") {
     return undefined;
   }
   if (swaggerType.additionalProperties === false) {


### PR DESCRIPTION
I fixed an error that caused me some headache, but I still don't think it's completely right now.
If a swagger object has an array of strings as "required" attribute, it will result in a type that has "isRequired" set to true. That doesn't feel right.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/119)