### PR TITLE
fix: invalid types such as Dictionary<void> are generated

### DIFF
--- a/src/type-mappers/void.ts
+++ b/src/type-mappers/void.ts
@@ -21,6 +21,7 @@ export interface VoidTypeSpec extends TypeSpec {
  * @returns {boolean} A boolean indicating that the SwaggerType should be annotated as a void typescript type.
  */
 export const isVoidType = (swaggerType: SwaggerType): boolean =>
+  Object.keys(swaggerType).length !== 0 &&
   (swaggerType.type as string | undefined) === undefined &&
   (swaggerType.required as boolean | string[] | undefined) === undefined &&
   swaggerType.$ref === undefined &&


### PR DESCRIPTION
The `object` type in C# outputs a Swagger definition as below:

```json
"Example": {
  "type": "object",
  "additionalProperties": { }
}
```

`additionalProperties` is then passed to `isVoidType()` and returns true
because all of the checked properties are undefined, and we end up with
e.g. `Dictionary<void>` instead of `Dictionary<{}>`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/126)