### PR TITLE
Add option to use query params in POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ mustache:
 imports:
   type: array
   description: Typescript definition files to be imported.
+convertQueryParamsToFormDataInPOST:
+  type: boolean
+  description: whether or not to convert query parameters in a POST request to form data.
 swagger:
   type: object
   required: true
@@ -193,6 +196,9 @@ methods:
       successfulResponseTypeIsRef:
         type: boolean
         description: True iff the successful response type is the name of a type defined in the Swagger schema.
+      convertQueryParamsToFormDataInPOST:
+        type: boolean
+        description: Provided by your options field
 ```
 
 #### Custom Mustache Variables

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -18,6 +18,7 @@ interface Options {
   readonly mustache: typeof Mustache;
   readonly beautify: ((source: string) => string) | boolean;
   readonly beautifyOptions: JsBeautifyOptions;
+  readonly convertQueryParamsToFormDataInPOST: boolean;
 }
 
 interface SwaggerOption {
@@ -33,7 +34,8 @@ const DEFAULT_OPTIONS: Options = {
   template: {},
   mustache: Mustache,
   beautify: true,
-  beautifyOptions: {}
+  beautifyOptions: {},
+  convertQueryParamsToFormDataInPOST: true
 };
 
 /**

--- a/src/view-data/method.ts
+++ b/src/view-data/method.ts
@@ -34,6 +34,7 @@ export interface Method {
   readonly parameters: TypeSpecParameter[];
   readonly headers: Header[];
   readonly responseTypes: string;
+  readonly convertQueryParamsToFormDataInPOST: boolean;
 
   /** @deprecated use responseTypes instead, this field will be removed in a future version. */
   readonly successfulResponseType: string;
@@ -89,7 +90,8 @@ export function makeMethod(
     successfulResponseType,
     successfulResponseTypeIsRef,
     responseTypes: renderResponseTypes(defaultResponseTypeName, op, swagger),
-    isLatestVersion: false
+    isLatestVersion: false,
+    convertQueryParamsToFormDataInPOST: opts.convertQueryParamsToFormDataInPOST
   };
 }
 

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -176,8 +176,10 @@ if(parameters.$queryParameters) {
 
     {{^isBodyParameter}}
         {{#isPOST}}
-            form = queryParameters;
-            queryParameters = {};
+            {{#convertQueryParamsToFormDataInPOST}}
+                form = queryParameters;
+                queryParameters = {};
+            {{/convertQueryParamsToFormDataInPOST}}
         {{/isPOST}}
     {{/isBodyParameter}}
 


### PR DESCRIPTION
Closes #124 

Adds an option to disable the behaviour of turning query parameters in a POST request into form data. The default remains to use form data in POST requests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/mtennoe/swagger-typescript-codegen/pull/130)